### PR TITLE
Cleanup socket connection tests

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,28 +1,34 @@
 import "./App.css";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 
 function App() {
-  let websocket = null;
+  let websocket = useRef(null);
   let websocketConnected = false;
 
   useEffect(() => {
-    websocket = new WebSocket("ws://localhost:8000/ws");
+    websocket.current = new WebSocket("ws://localhost:8000/ws");
 
-    websocket.onopen = () => {
+    websocket.current.onopen = () => {
       console.log("WebSocket Connected to React");
+      websocket.current.send("Websocket Connected to React")
       websocketConnected = true;
     };
 
-    websocket.onmessage = function(event) {
+    websocket.current.onmessage = function(event) {
       console.log("Data received from backend: ", event.data);
     };
 
-    websocket.onclose = (event) => {
+    websocket.current.onclose = (event) => {
       console.log("WebSocket connection closed: ", event);
       websocketConnected = false;
     };
 
-    return () => {};
+    return () => {
+      if (websocket.current) {
+        websocket.current.close();
+        console.log("WebSocket connection closed during cleanup");
+      }
+    };
   }, []);
 
   return (

--- a/frontend/src/App.test.js
+++ b/frontend/src/App.test.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render } from '@testing-library/react';
 import { act } from 'react';
 import App from './App';
@@ -12,6 +11,7 @@ describe('WebSocket in App Component', () => {
   });
 
   afterEach(() => {
+    server.close();
     WS.clean();
   });
 
@@ -33,34 +33,45 @@ describe('WebSocket in App Component', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith("Data received from backend: ", "Message from backend");
 
     consoleLogSpy.mockRestore();
-
-    server.close();
+ 
   });
-
   test('Message on WebSocket connection open', async () => {
     await act(async () => {
       render(<App />);
     });
-
-    await server.connected;
-
-    expect(server).toReceiveMessage("Websocket Connected to React");
-
-    server.close();
+   
+    // Wait for the server connection to be established
+    await server.connected; 
+  
+    // Wait a bit to ensure the message is sent
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    });
+    
+    // Check if the WebSocket has received the expected message
+    expect(server).toHaveReceivedMessages(["Websocket Connected to React"]); 
 
   });
+  
+
 
   test("User is notified on WS Close", async () => {
+    const consoleLogSpy = jest.spyOn(console, 'log');
+  
     await act(async () => {
-      render(<App />);
+      render(<App />); 
     });
-
+  
     await server.connected;
-
-    expect(server).toReceiveMessage("Websocket Connected to React");
-
-    server.close();
-
-    expect(server).toReceiveMessage("WebSocket connection closed:");
+  
+    // Simulate WebSocket close
+    await act(async () => {
+      server.close();
+    });
+  
+    // Check if "WebSocket connection closed" is logged
+    expect(consoleLogSpy).toHaveBeenCalledWith("WebSocket connection closed: ", expect.any(Object));
+   
+    consoleLogSpy.mockRestore();
   });
 });


### PR DESCRIPTION
Fixes #20 
Changes made in:
-  `/frontent/App.js`: store WebSocket (ws) in React `useRef() `to prevent multiple creations of ws on every occasion of component mount.
   - send message to connection: so that that message can be looked for in `App.test.js`
![image](https://github.com/user-attachments/assets/38978648-475b-4e8e-a6e3-75cff80b835a)

   - update all appearances of `ws` to reflect its new state as a ref
   - return a cleanup function to close the WebSocket connection on component unmount

- `/frontend/App.test.js`: inline comments reflect changes made