### PR TITLE
Added Paramaterization to Step Time Calculation Function

### DIFF
--- a/backend/Step_Time_Calculation.py
+++ b/backend/Step_Time_Calculation.py
@@ -1,12 +1,13 @@
 import numpy as np
 
-def calculate_step_time(force_data, threshold=20.0):
+def calculate_step_time(force_data, threshold=20.0, moving_avg_factor=2):
     """
     Calculate step time from force data collected from a Bertec treadmill.
 
     Parameters:
     force_data (list): A list of tuples where each tuple contains (time, force).
     threshold (float): The force threshold to determine heel strikes and toe-offs.
+    moving_avg_factor (int): The moving average factor.
 
     Returns:
     list: A list of calculated step times in seconds
@@ -25,13 +26,16 @@ def calculate_step_time(force_data, threshold=20.0):
             step_time = time - step_start_time  # Calculate step duration
             step_times.append(step_time)
             step_start_time = None  # Reset for the next step
-            
     
+    # return before calculating moving_avg -> MAY BE REMOVED... waiting for clarification 
+    if moving_avg_factor < 2:
+        return step_time
+
     for i in range(len(step_times)):
-        if i == 0:
-            step_time_moving_averages.append(step_times[i])  # First step time stays the same
+        if i < moving_avg_factor - 1:
+            step_time_moving_averages.append(step_times[i]) 
         else:
-            moving_average = np.mean(step_times[i-1:i+1])  # 2-point moving average
+            moving_average = np.mean(step_times[i - moving_avg_factor + 1:i+1])  
             step_time_moving_averages.append(moving_average)  
             
     return step_times

--- a/backend/Step_Time_Calculation.py
+++ b/backend/Step_Time_Calculation.py
@@ -27,9 +27,8 @@ def calculate_step_time(force_data, threshold=20.0, moving_avg_factor=2):
             step_times.append(step_time)
             step_start_time = None  # Reset for the next step
     
-    # return before calculating moving_avg -> MAY BE REMOVED... waiting for clarification 
     if moving_avg_factor < 2:
-        return step_time
+        return step_times
 
     for i in range(len(step_times)):
         if i < moving_avg_factor - 1:
@@ -38,5 +37,5 @@ def calculate_step_time(force_data, threshold=20.0, moving_avg_factor=2):
             moving_average = np.mean(step_times[i - moving_avg_factor + 1:i+1])  
             step_time_moving_averages.append(moving_average)  
             
-    return step_times
+    return step_time_moving_averages
 

--- a/backend/test_step_time.py
+++ b/backend/test_step_time.py
@@ -39,6 +39,3 @@ class TestCalculateStepTime(unittest.TestCase):
         self.assertAlmostEqual(step_time_moving_averages[1], 0.3, places=2)
         self.assertAlmostEqual(step_time_moving_averages[2], 0.233, places=3)
         self.assertAlmostEqual(step_time_moving_averages[2], 0.233, places=3)
-
-if __name__ == "__main__":
-    unittest.main();

--- a/backend/test_step_time.py
+++ b/backend/test_step_time.py
@@ -3,52 +3,42 @@ from Step_Time_Calculation import calculate_step_time
 
 class TestCalculateStepTime(unittest.TestCase):
 
-    def test_step_time_below_threshold(self):
+    def test_step_time_avgs_below_threshold(self):
         # All values below threshold should yield no step times
         force_data = [(0.0, 0), (0.1, 0), (0.2, 10), (0.3, 15)]
-        step_times = calculate_step_time(force_data)
-        self.assertEqual(step_times, [])  # Expected: []
+        step_time_moving_averages = calculate_step_time(force_data)
+        self.assertEqual(step_time_moving_averages, [])  # Expected: []
     
-    def test_step_time_below_non_default_threshold(self):
-        force_data = [(0.0, 0), (0.1, 10), (0.2, 20), (0.3, 25)]
-        step_times = calculate_step_time(force_data, 30)
-        self.assertEqual(step_times, [])
-    
-    def test_step_time_at_or_above_non_default_threshold(self):
+    def test_step_time_avgs_at_or_above_threshold(self):
         force_data = [
-            (0.0, 0), (0.1, 25), (0.2, 30), (0.3, 25),  
-            (0.4, 0), (0.5, 30), (0.6, 40), (0.7, 15)   
+            (0.0, 0), (0.1, 30), (0.2, 25), (0.3, 35),  
+            (0.4, 40), (0.5, 20), (0.6, 10), (0.7, 0)   
         ]
-        step_times = calculate_step_time(force_data, 30)
-        self.assertAlmostEqual(step_times[0], 0.1, places=2)
-        self.assertAlmostEqual(step_times[1], 0.2, places=2)
+        step_time_moving_averages = calculate_step_time(force_data, 30)
+        self.assertAlmostEqual(step_time_moving_averages[0], 0.1, places=2)
+        self.assertAlmostEqual(step_time_moving_averages[1], 0.15, places=2)
      
-    def test_step_time_calculation(self):
-        # Adjusted force data
+    def test_moving_avg_factor_below_two(self):
         force_data = [
-            (0.0, 0), (0.1, 25), (0.2, 30), (0.3, 0),  # First step
-            (0.4, 0), (0.5, 25), (0.6, 30), (0.7, 0)   # Second step
+            (0.0, 0), (0.1, 25), (0.2, 30), (0.3, 0),  
+            (0.4, 0), (0.5, 25), (0.6, 30), (0.7, 0)   
         ]
-        step_times = calculate_step_time(force_data)
-        # Check if the step times are approximately equal to expected values
+        step_times = calculate_step_time(force_data, moving_avg_factor=1)
         self.assertAlmostEqual(step_times[0], 0.2, places = 2)
         self.assertAlmostEqual(step_times[1], 0.2, places = 2) 
 
-    def test_moving_average(self):
+    def test_moving_avg_factor_above_two(self):
         force_data = [
-            (0.0, 0), (0.1, 25), (0.2, 30), (0.3, 0),
-            (0.4, 0), (0.5, 25), (0.6, 30), (0.7, 0)
+            (0.0, 0), (0.1, 25), (0.2, 30), (0.3, 0),  # 0.2 
+            (0.4, 40), (0.5, 45), (0.6, 50), (0.7, 0), # 0.3
+            (0.8, 20), (0.9, 25), (1.0, 0), (1.1, 0),  # 0.2
+            (1.2, 40), (1.3, 45), (1.4, 50), (1.5, 0), # 0.2
         ]
-        step_times = calculate_step_time(force_data)
-        # Check if the step times are approximately equal to expected values
-        self.assertAlmostEqual(step_times[0], 0.2, places = 2)
-        self.assertAlmostEqual(step_times[1], 0.2, places = 2) 
-    
-    def test_non_default_moving_avg_factor(self):
-        force_data = [
-            (0.0, 0), (0.1, 25), (0.2, 30), (0.3, 25),  
-            (0.4, 0), (0.5, 30), (0.6, 40), (0.7, 15)   
-        ]
-        step_times = calculate_step_time(force_data, 30)
-        self.assertAlmostEqual(step_times[0], 0.1, places=2)
-        self.assertAlmostEqual(step_times[1], 0.2, places=2)
+        step_time_moving_averages = calculate_step_time(force_data, moving_avg_factor=3)
+        self.assertAlmostEqual(step_time_moving_averages[0], 0.2, places=2)
+        self.assertAlmostEqual(step_time_moving_averages[1], 0.3, places=2)
+        self.assertAlmostEqual(step_time_moving_averages[2], 0.233, places=3)
+        self.assertAlmostEqual(step_time_moving_averages[2], 0.233, places=3)
+
+if __name__ == "__main__":
+    unittest.main();

--- a/backend/test_step_time.py
+++ b/backend/test_step_time.py
@@ -8,6 +8,20 @@ class TestCalculateStepTime(unittest.TestCase):
         force_data = [(0.0, 0), (0.1, 0), (0.2, 10), (0.3, 15)]
         step_times = calculate_step_time(force_data)
         self.assertEqual(step_times, [])  # Expected: []
+    
+    def test_step_time_below_non_default_threshold(self):
+        force_data = [(0.0, 0), (0.1, 10), (0.2, 20), (0.3, 25)]
+        step_times = calculate_step_time(force_data, 30)
+        self.assertEqual(step_times, [])
+    
+    def test_step_time_at_or_above_non_default_threshold(self):
+        force_data = [
+            (0.0, 0), (0.1, 25), (0.2, 30), (0.3, 25),  
+            (0.4, 0), (0.5, 30), (0.6, 40), (0.7, 15)   
+        ]
+        step_times = calculate_step_time(force_data, 30)
+        self.assertAlmostEqual(step_times[0], 0.1, places=2)
+        self.assertAlmostEqual(step_times[1], 0.2, places=2)
      
     def test_step_time_calculation(self):
         # Adjusted force data
@@ -29,3 +43,12 @@ class TestCalculateStepTime(unittest.TestCase):
         # Check if the step times are approximately equal to expected values
         self.assertAlmostEqual(step_times[0], 0.2, places = 2)
         self.assertAlmostEqual(step_times[1], 0.2, places = 2) 
+    
+    def test_non_default_moving_avg_factor(self):
+        force_data = [
+            (0.0, 0), (0.1, 25), (0.2, 30), (0.3, 25),  
+            (0.4, 0), (0.5, 30), (0.6, 40), (0.7, 15)   
+        ]
+        step_times = calculate_step_time(force_data, 30)
+        self.assertAlmostEqual(step_times[0], 0.1, places=2)
+        self.assertAlmostEqual(step_times[1], 0.2, places=2)


### PR DESCRIPTION
Fixes #32 

What was changed:
- Added functionality to allow non-default threshold and moving average factor values to calculate step time and step time moving averages.
- Added testing to check that the new functionality for threshold and a moving average factor works as intended.

Why it was changed:
- The threshold and moving average factors were changed from constant values to allow researchers to calculate step times and moving averages based on a new threshold and moving average factor respectively.
- Testing was added to ensure the new functionality works as intended and to create a fail-safe for future changes that could break the intended functionality.

How it was changed:
- Updated the step_time_calculation function to take a new moving_avg_factor parameter with a default of 2. 
- Updated the step_time_moving_average calculation to compare against a moving average factor instead of a constant value.
- Updated the step_time_calculation function to return early if the moving_avg_factor was below 2.
- Updated the test_step_time module to test for non-default values for threshold and moving average factor and ensure the proper output is returned.