### PR TITLE
Adding a reconnect button for websocket disconnection

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -109,6 +109,7 @@ return (
         {isWebSocketConnected
           ? "Connection established"
           : webSocketError || "Waiting for WebSocket connection..."}
+        {!isWebSocketConnected && <button>Reconnect</button>}
       </div>
   
       {/* Page Content */}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,5 @@
 import './App.css';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import Navigation from './Navigation';
 import StepTimeDigits from './StepTimeDigits';
 import StepTimeChart from './StepTimeChart';
@@ -58,55 +58,55 @@ function App() {
     });
   }
 
-  const reconnectWebsocket = () => {
+  const reconnectWebsocket = useCallback(() => {
     if (websocket.current) {
-      websocket.current.close();  // Close the existing WebSocket connection
+      websocket.current.close();
       console.log("WebSocket connection closed manually.");
     }
-    // Reopen a new WebSocket connection
+  
     websocket.current = new WebSocket("ws://localhost:8000/ws");
-
+  
     websocket.current.onopen = () => {
       console.log("WebSocket Connected to React");
       setIsWebSocketConnected(true);
       websocket.current.send("Websocket Connected to React");
     };
-
+  
     websocket.current.onmessage = (event) => {
       console.log("Data received from backend");
       const data = JSON.parse(event.data);
-
+  
       if (data.message_type === "Force Data") {
         updateVisualThreshold(data.force);
       } else if (data.message_type === "Target Zone") {
         updateTargetZones(data);
       }
     };
-
+  
     websocket.current.onclose = (event) => {
       console.log("WebSocket connection closed: ", event);
       setIsWebSocketConnected(false);
       setWebSocketError("WebSocket connection closed. Data streaming stopped.");
     };
-
+  
     websocket.current.onerror = (event) => {
       console.log("WebSocket error: ", event);
       setWebSocketError("WebSocket encountered an error. Data streaming stopped.");
     };
-  };
+  }, []);
 
   let websocket = useRef(null);
 
   useEffect(() => {
-    reconnectWebsocket();  // Open the initial WebSocket connection
-
+    reconnectWebsocket();
+  
     return () => {
       if (websocket.current) {
         websocket.current.close();
         console.log("WebSocket connection closed during cleanup");
       }
     };
-  }, []);
+  }, [reconnectWebsocket]);
 
 return (
     <div className="App">

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -68,7 +68,7 @@ function App() {
   
     websocket.current.onopen = () => {
       console.log("WebSocket Connected to React");
-      setIsWebSocketConnected(true);
+      setIsWebSocketConnected(true); // Update state when connected
       websocket.current.send("Websocket Connected to React");
     };
   
@@ -85,7 +85,7 @@ function App() {
   
     websocket.current.onclose = (event) => {
       console.log("WebSocket connection closed: ", event);
-      setIsWebSocketConnected(false);
+      setIsWebSocketConnected(false); // Update state when connected
       setWebSocketError("WebSocket connection closed. Data streaming stopped.");
     };
   

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,7 +8,6 @@ import StepTimeTredmill from './StepTimeTreadmil';
 
 function App() {
   const [currentView, setCurrentView] = useState('StepTimeDigits');
-
   const [stepTime, setStepTime] = useState({
     left: 0, 
     right: 0,
@@ -18,8 +17,9 @@ function App() {
     } 
   });
 
-  const [isWebSocketConnected, setIsWebSocketConnected] = useState(false); // WebSocket connection state
-  const [webSocketError, setWebSocketError] = useState(null); // For displaying errors to the user
+  const [isWebSocketConnected, setIsWebSocketConnected] = useState(false);
+  const [webSocketError, setWebSocketError] = useState(null);
+  const websocket = useRef(null);
 
   const views = {
     StepTimeDigits: <StepTimeDigits stepTime={stepTime} />,
@@ -29,20 +29,11 @@ function App() {
   };
 
   function updateVisualThreshold(forceData) {
-    let color = null;
-
-    if (forceData <= 19.00 && forceData >= 18.00) {
-      color = "yellow";
-    } else if (forceData < 18.00) {
-      color = "red";
-    } else {
-      color = "green";
-    }
+    let color = forceData >= 18.00 && forceData <= 19.00 ? "yellow" :
+                forceData < 18.00 ? "red" : "green";
 
     console.log(color);
-  
-    const elements = document.querySelectorAll(".CurrentStepTime li");
-    elements.forEach(element => {
+    document.querySelectorAll(".CurrentStepTime li").forEach(element => {
       element.style.borderColor = color;
     });
   }
@@ -58,34 +49,33 @@ function App() {
     });
   }
 
-  let websocket = useRef(null);
+  function setupWebSocket() {
+    if (websocket.current) {
+      websocket.current.close();
+    }
 
-  useEffect(() => {
     websocket.current = new WebSocket("ws://localhost:8000/ws");
 
     websocket.current.onopen = () => {
       console.log("WebSocket Connected to React");
-      setIsWebSocketConnected(true);  // Update state when connected
-      websocket.current.send("Websocket Connected to React");
+      setIsWebSocketConnected(true);
+      websocket.current.send("WebSocket Connected to React");
     };
 
-    websocket.current.onmessage = function (event) {
+    websocket.current.onmessage = (event) => {
       console.log("Data received from backend");
-      // Your logic for processing the received data
-
       const data = JSON.parse(event.data); 
 
-      if(data.message_type === "Force Data"){
+      if (data.message_type === "Force Data") {
         updateVisualThreshold(data.force);
-      }
-      else if(data.message_type === "Target Zone"){
+      } else if (data.message_type === "Target Zone") {
         updateTargetZones(data);
       }
     };
 
     websocket.current.onclose = (event) => {
       console.log("WebSocket connection closed: ", event);
-      setIsWebSocketConnected(false); // Update state when closed
+      setIsWebSocketConnected(false);
       setWebSocketError("WebSocket connection closed. Data streaming stopped.");
     };
 
@@ -93,7 +83,15 @@ function App() {
       console.log("WebSocket error: ", event);
       setWebSocketError("WebSocket encountered an error. Data streaming stopped.");
     };
+  }
 
+  function reconnectWebsocket() {
+    setupWebSocket();
+  }
+
+  useEffect(() => {
+    setupWebSocket();
+    
     return () => {
       if (websocket.current) {
         websocket.current.close();
@@ -102,13 +100,14 @@ function App() {
     };
   }, []);
 
-return (
+  return (
     <div className="App">
       {/* WebSocket Status Banner */}
       <div className={`WebSocketBanner ${isWebSocketConnected ? 'connected' : 'disconnected'}`}>
         {isWebSocketConnected
           ? "Connection established"
           : webSocketError || "Waiting for WebSocket connection..."}
+        {!isWebSocketConnected && <button onClick={reconnectWebsocket}>Reconnect</button>}
       </div>
   
       {/* Page Content */}

--- a/frontend/src/__tests__/App.test.js
+++ b/frontend/src/__tests__/App.test.js
@@ -7,14 +7,11 @@ test("Navbar is rendered on screen", () => {
   expect(screen.getByRole("navigation")).toBeInTheDocument();
 });
 
-jest.setTimeout(10000);
-
-describe("StepTime view changes", () => {
+describe("Steptime view changes", () => {
   let server;
 
-  beforeEach(async () => {
-    server = new WS("ws://localhost:8000/ws", { jsonProtocol: true });
-    await server.connected; // Ensure connection before sending messages
+  beforeEach(() => {
+    server = new WS("ws://localhost:8000/ws");
   });
 
   afterEach(() => {
@@ -23,15 +20,16 @@ describe("StepTime view changes", () => {
 
   test("Force Threshold Green Test", async () => {
     render(<App />);
-    await server.connected;
 
-    await server.send({
-      message_type: "Force Data",
-      time: 0.00093,
-      force: 21.4233408,
-    });
+    server.send(
+      JSON.stringify({
+        message_type: "Force Data",
+        time: 0.00093,
+        force: 21.4233408,
+      })
+    );
 
-    const elements = await screen.findAllByTestId("current-step-time-left");
+    const elements = await screen.findAllByTestId(/current-step-time-left/);
 
     elements.forEach((element) => {
       expect(element).toHaveStyle("border-color: green");
@@ -40,15 +38,16 @@ describe("StepTime view changes", () => {
 
   test("Force Threshold Yellow Test", async () => {
     render(<App />);
-    await server.connected;
 
-    await server.send({
-      message_type: "Force Data",
-      time: 0.00093,
-      force: 18.5,
-    });
+    server.send(
+      JSON.stringify({
+        message_type: "Force Data",
+        time: 0.00093,
+        force: 18.5,
+      })
+    );
 
-    const elements = await screen.findAllByTestId("current-step-time-left");
+    const elements = await screen.findAllByTestId(/current-step-time-left/);
 
     elements.forEach((element) => {
       expect(element).toHaveStyle("border-color: yellow");
@@ -57,15 +56,16 @@ describe("StepTime view changes", () => {
 
   test("Force Threshold Red Test", async () => {
     render(<App />);
-    await server.connected;
 
-    await server.send({
-      message_type: "Force Data",
-      time: 0.00093,
-      force: 1.4233408,
-    });
+    server.send(
+      JSON.stringify({
+        message_type: "Force Data",
+        time: 0.00093,
+        force: 1.4233408,
+      })
+    );
 
-    const elements = await screen.findAllByTestId("current-step-time-left");
+    const elements = await screen.findAllByTestId(/current-step-time-left/);
 
     elements.forEach((element) => {
       expect(element).toHaveStyle("border-color: red");
@@ -103,9 +103,8 @@ describe("View Swapping", () => {
 describe("WebSocket in App Component", () => {
   let server;
 
-  beforeEach(async () => {
-    server = new WS("ws://localhost:8000/ws", { jsonProtocol: true });
-    await server.connected;
+  beforeEach(() => {
+    server = new WS("ws://localhost:8000/ws");
   });
 
   afterEach(() => {
@@ -114,14 +113,18 @@ describe("WebSocket in App Component", () => {
 
   test("WebSocket connection messages", async () => {
     const consoleLogSpy = jest.spyOn(console, "log");
+
     render(<App />);
+
     await server.connected;
 
-    await server.send({
-      message_type: "Force Data",
-      time: 0.00093,
-      force: 21.4233408,
-    });
+    server.send(
+      JSON.stringify({
+        message_type: "Force Data",
+        time: 0.00093,
+        force: 21.4233408,
+      })
+    );
 
     await new Promise((resolve) => setTimeout(resolve, 100));
 
@@ -132,14 +135,17 @@ describe("WebSocket in App Component", () => {
 
   test("Message on WebSocket connection open", async () => {
     render(<App />);
+
     await server.connected;
-    await expect(server).toReceiveMessage("Websocket Connected to React");
+
+    expect(server).toReceiveMessage("Websocket Connected to React");
   });
 
   test("User is notified on WS Close", async () => {
     const consoleLogSpy = jest.spyOn(console, "log");
 
     render(<App />);
+
     await server.connected;
 
     server.close();

--- a/frontend/src/__tests__/App.test.js
+++ b/frontend/src/__tests__/App.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import App from "../App";
 import WS from "jest-websocket-mock";
 
@@ -31,10 +31,8 @@ describe("Steptime view changes", () => {
 
     const elements = await screen.findAllByTestId(/current-step-time-left/);
 
-    await waitFor(() => {
-      elements.forEach((element) => {
-        expect(element).toHaveStyle("border-color: green");
-      });
+    elements.forEach((element) => {
+      expect(element).toHaveStyle("border-color: green");
     });
   });
 
@@ -51,10 +49,8 @@ describe("Steptime view changes", () => {
 
     const elements = await screen.findAllByTestId(/current-step-time-left/);
 
-    await waitFor(() => {
-      elements.forEach((element) => {
-        expect(element).toHaveStyle("border-color: yellow");
-      });
+    elements.forEach((element) => {
+      expect(element).toHaveStyle("border-color: yellow");
     });
   });
 
@@ -71,10 +67,8 @@ describe("Steptime view changes", () => {
 
     const elements = await screen.findAllByTestId(/current-step-time-left/);
 
-    await waitFor(() => {
-      elements.forEach((element) => {
-        expect(element).toHaveStyle("border-color: red");
-      });
+    elements.forEach((element) => {
+      expect(element).toHaveStyle("border-color: red");
     });
   });
 });
@@ -132,9 +126,9 @@ describe("WebSocket in App Component", () => {
       })
     );
 
-    await waitFor(() => {
-      expect(consoleLogSpy).toHaveBeenCalledWith("Data received from backend");
-    });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(consoleLogSpy).toHaveBeenCalledWith("Data received from backend");
 
     consoleLogSpy.mockRestore();
   });

--- a/frontend/src/__tests__/App.test.js
+++ b/frontend/src/__tests__/App.test.js
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import App from "../App";
 import WS from "jest-websocket-mock";
 
@@ -31,8 +31,10 @@ describe("Steptime view changes", () => {
 
     const elements = await screen.findAllByTestId(/current-step-time-left/);
 
-    elements.forEach((element) => {
-      expect(element).toHaveStyle("border-color: green");
+    await waitFor(() => {
+      elements.forEach((element) => {
+        expect(element).toHaveStyle("border-color: green");
+      });
     });
   });
 
@@ -49,8 +51,10 @@ describe("Steptime view changes", () => {
 
     const elements = await screen.findAllByTestId(/current-step-time-left/);
 
-    elements.forEach((element) => {
-      expect(element).toHaveStyle("border-color: yellow");
+    await waitFor(() => {
+      elements.forEach((element) => {
+        expect(element).toHaveStyle("border-color: yellow");
+      });
     });
   });
 
@@ -67,8 +71,10 @@ describe("Steptime view changes", () => {
 
     const elements = await screen.findAllByTestId(/current-step-time-left/);
 
-    elements.forEach((element) => {
-      expect(element).toHaveStyle("border-color: red");
+    await waitFor(() => {
+      elements.forEach((element) => {
+        expect(element).toHaveStyle("border-color: red");
+      });
     });
   });
 });
@@ -126,9 +132,9 @@ describe("WebSocket in App Component", () => {
       })
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 100));
-
-    expect(consoleLogSpy).toHaveBeenCalledWith("Data received from backend");
+    await waitFor(() => {
+      expect(consoleLogSpy).toHaveBeenCalledWith("Data received from backend");
+    });
 
     consoleLogSpy.mockRestore();
   });

--- a/frontend/src/__tests__/App.test.js
+++ b/frontend/src/__tests__/App.test.js
@@ -7,11 +7,12 @@ test("Navbar is rendered on screen", () => {
   expect(screen.getByRole("navigation")).toBeInTheDocument();
 });
 
-describe("Steptime view changes", () => {
+describe("StepTime view changes", () => {
   let server;
 
-  beforeEach(() => {
-    server = new WS("ws://localhost:8000/ws");
+  beforeEach(async () => {
+    server = new WS("ws://localhost:8000/ws", { jsonProtocol: true });
+    await server.connected; // Ensure connection before sending messages
   });
 
   afterEach(() => {
@@ -20,16 +21,15 @@ describe("Steptime view changes", () => {
 
   test("Force Threshold Green Test", async () => {
     render(<App />);
+    await server.connected;
 
-    server.send(
-      JSON.stringify({
-        message_type: "Force Data",
-        time: 0.00093,
-        force: 21.4233408,
-      })
-    );
+    await server.send({
+      message_type: "Force Data",
+      time: 0.00093,
+      force: 21.4233408,
+    });
 
-    const elements = await screen.findAllByTestId(/current-step-time-left/);
+    const elements = await screen.findAllByTestId("current-step-time-left");
 
     elements.forEach((element) => {
       expect(element).toHaveStyle("border-color: green");
@@ -38,16 +38,15 @@ describe("Steptime view changes", () => {
 
   test("Force Threshold Yellow Test", async () => {
     render(<App />);
+    await server.connected;
 
-    server.send(
-      JSON.stringify({
-        message_type: "Force Data",
-        time: 0.00093,
-        force: 18.5,
-      })
-    );
+    await server.send({
+      message_type: "Force Data",
+      time: 0.00093,
+      force: 18.5,
+    });
 
-    const elements = await screen.findAllByTestId(/current-step-time-left/);
+    const elements = await screen.findAllByTestId("current-step-time-left");
 
     elements.forEach((element) => {
       expect(element).toHaveStyle("border-color: yellow");
@@ -56,16 +55,15 @@ describe("Steptime view changes", () => {
 
   test("Force Threshold Red Test", async () => {
     render(<App />);
+    await server.connected;
 
-    server.send(
-      JSON.stringify({
-        message_type: "Force Data",
-        time: 0.00093,
-        force: 1.4233408,
-      })
-    );
+    await server.send({
+      message_type: "Force Data",
+      time: 0.00093,
+      force: 1.4233408,
+    });
 
-    const elements = await screen.findAllByTestId(/current-step-time-left/);
+    const elements = await screen.findAllByTestId("current-step-time-left");
 
     elements.forEach((element) => {
       expect(element).toHaveStyle("border-color: red");
@@ -103,8 +101,9 @@ describe("View Swapping", () => {
 describe("WebSocket in App Component", () => {
   let server;
 
-  beforeEach(() => {
-    server = new WS("ws://localhost:8000/ws");
+  beforeEach(async () => {
+    server = new WS("ws://localhost:8000/ws", { jsonProtocol: true });
+    await server.connected;
   });
 
   afterEach(() => {
@@ -113,18 +112,14 @@ describe("WebSocket in App Component", () => {
 
   test("WebSocket connection messages", async () => {
     const consoleLogSpy = jest.spyOn(console, "log");
-
     render(<App />);
-
     await server.connected;
 
-    server.send(
-      JSON.stringify({
-        message_type: "Force Data",
-        time: 0.00093,
-        force: 21.4233408,
-      })
-    );
+    await server.send({
+      message_type: "Force Data",
+      time: 0.00093,
+      force: 21.4233408,
+    });
 
     await new Promise((resolve) => setTimeout(resolve, 100));
 
@@ -135,17 +130,14 @@ describe("WebSocket in App Component", () => {
 
   test("Message on WebSocket connection open", async () => {
     render(<App />);
-
     await server.connected;
-
-    expect(server).toReceiveMessage("Websocket Connected to React");
+    await expect(server).toReceiveMessage("Websocket Connected to React");
   });
 
   test("User is notified on WS Close", async () => {
     const consoleLogSpy = jest.spyOn(console, "log");
 
     render(<App />);
-
     await server.connected;
 
     server.close();

--- a/frontend/src/__tests__/App.test.js
+++ b/frontend/src/__tests__/App.test.js
@@ -7,6 +7,8 @@ test("Navbar is rendered on screen", () => {
   expect(screen.getByRole("navigation")).toBeInTheDocument();
 });
 
+jest.setTimeout(10000);
+
 describe("StepTime view changes", () => {
   let server;
 


### PR DESCRIPTION
Fixes #63 

What was changed:
The disconnected banner was changed to add a reconnect button

Why was this changed:
This was changed because the users had no way to reconnect the websocket if the connection was dropped, rendering the app useless. 

How was this changed:
I added a button to appear when the websocket disconnected. I changed how the webosckets connect by creating a setup websocket function that can be called more than once