### PR TITLE
Help Button Popup

### DIFF
--- a/frontend/src/StanceTimeTreadmil.js
+++ b/frontend/src/StanceTimeTreadmil.js
@@ -1,6 +1,9 @@
+import { useState } from "react";
 import "./StanceTimeTreadmill.css";
 
 function StanceTimeTreadmill({ stanceTime }) {
+  const [showHelpText, setShowHelpText] = useState(false);
+
   const scaleFactor = 50;
   const leftScaleFactor = scaleFactor / stanceTime.left;
   const rightScaleFactor = scaleFactor / stanceTime.right;
@@ -19,65 +22,52 @@ function StanceTimeTreadmill({ stanceTime }) {
   let leftCurrent = Math.floor(Math.random() * 80);
   let rightCurrent = Math.floor(Math.random() * 80);
 
-  console.log("leftCurrent:", leftCurrent, "leftMinPosition:", leftMinPosition);
-  console.log("rightCurrent:", leftCurrent, "rightMinPosition:", leftMinPosition);
-
+  function hideHelp() {
+    if (showHelpText) {
+      setShowHelpText(false);
+    }
+  }
+  
   return (
-    <div
-      data-testid="stance-time-treadmill-view"
-      className="StanceTimeTreadmill"
-    >
-      <div className="visual-key">
-        <ul>
-          <li>
-            <strong>
-              <u>Key</u>
-            </strong>
-          </li>
-          <li>
-            <strong>Stance Time Range:</strong> The blue rectagles represents the upper
-            and lower bounds of the stance time range the user should be aiming for. There
-            is a range for the left and right foot respectively.
-          </li>
-          <li>
-            <strong>X's and O's:</strong> If the current step is within the target zone, 
-            a circle will appear. If not a X will show the step was out of range.
-          </li>
-        </ul>
-      </div>
-      <svg
-        data-testid="treadmill-svg"
-        className="Treadmill"
-        viewBox="0 0 100 100"
-        preserveAspectRatio="none"
+    <div data-testid="stance-time-treadmill-view" className="StanceTimeTreadmill" onClick={hideHelp}>
+      <div className="stance-time-treadmill-container">
+      <button 
+        onClick={() => setShowHelpText(true)}
+        className="help-button"
       >
+        Show Help
+      </button>
+
+      {showHelpText && (
+        <div className="popup-overlay">
+          <div className="popup-content">
+            <h2>Help Guide</h2>
+            <ul>
+              <li><strong>Stance Time Range:</strong> The blue rectangles represent the stance time range bounds for the left and right foot.</li>
+              <li><strong>X's and O's:</strong> A circle appears if the step is within range; otherwise, an X shows the step was out of range.</li>
+              <li><strong>Baseline:</strong> The horizontal line represents the normal stance time position.</li>
+            </ul>
+            <button 
+              onClick={() => setShowHelpText(false)}
+              className="close-button"
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      )}
+      </div>
+
+      <svg data-testid="treadmill-svg" className="Treadmill" viewBox="0 0 100 100" preserveAspectRatio="none">
         <g data-testid="target-zones" className="TargetZones">
           <g data-testid="baseline" className="YAxis">
             <line x1="5" x2="5" y1="0" y2="100" />
           </g>
-          {/* <g>
-            <text x="29" y="95" textAnchor="middle" fontSize="4"> Left</text>
-          </g>
-          <g>
-            <text x="79" y="95" textAnchor="middle" fontSize="4"> Right</text>
-          </g> */}
           <g data-testid="left-target-zones" className="LeftTargetZones">
-            <rect
-              className="max-zone"
-              x="24"
-              y={leftMinPosition}
-              width="10"
-              height={leftMaxPosition - leftMinPosition}
-            />
+            <rect className="max-zone" x="24" y={leftMinPosition} width="10" height={leftMaxPosition - leftMinPosition} />
           </g>
           <g data-testid="right-target-zones" className="RightTargetZones">
-            <rect
-              className="max-zone"
-              x="74"
-              y={rightMinPosition}
-              width="10"
-              height={rightMaxPosition - rightMinPosition}
-            />
+            <rect className="max-zone" x="74" y={rightMinPosition} width="10" height={rightMaxPosition - rightMinPosition} />
           </g>
           <g data-testid="baseline" className="Baseline">
             <line x1="5" x2="90" y1="50" y2="50" />
@@ -86,26 +76,27 @@ function StanceTimeTreadmill({ stanceTime }) {
         <g data-testid="stance-time-values" className="StanceTimeValues">
           <g data-testid="left-step-mark" className="LeftStep">
             {leftCurrent <= leftMaxPosition && leftCurrent >= leftMinPosition ? (
-              <circle cx="29" cy={leftCurrent} r="1.5" fill="green"/>
+              <circle cx="29" cy={leftCurrent} r="1.5" fill="green" />
             ) : (
               <>
-                <line x1="27" y1={leftCurrent - 1.5} x2="31" y2={leftCurrent + 1.5} stroke="red" strokeWidth="2"/>
-                <line x1="27" y1={leftCurrent + 1.5} x2="31" y2={leftCurrent - 1.5} stroke="red" strokeWidth="2"/>
+                <line x1="27" y1={leftCurrent - 1.5} x2="31" y2={leftCurrent + 1.5} stroke="red" strokeWidth="2" />
+                <line x1="27" y1={leftCurrent + 1.5} x2="31" y2={leftCurrent - 1.5} stroke="red" strokeWidth="2" />
               </>
             )}
           </g>
           <g data-testid="right-step-mark" className="RightStep">
             {rightCurrent <= rightMaxPosition && rightCurrent >= rightMinPosition ? (
-              <circle cx="79" cy={rightCurrent} r="1.5" fill="green"/>
+              <circle cx="79" cy={rightCurrent} r="1.5" fill="green" />
             ) : (
               <>
-                <line x1="77" y1={rightCurrent - 1.5} x2="81" y2={rightCurrent + 1.5} stroke="red" strokeWidth="2"/>
-                <line x1="77" y1={rightCurrent + 1.5} x2="81" y2={rightCurrent - 1.5} stroke="red" strokeWidth="2"/>
+                <line x1="77" y1={rightCurrent - 1.5} x2="81" y2={rightCurrent + 1.5} stroke="red" strokeWidth="2" />
+                <line x1="77" y1={rightCurrent + 1.5} x2="81" y2={rightCurrent - 1.5} stroke="red" strokeWidth="2" />
               </>
             )}
           </g>
         </g>
       </svg>
+
       <svg data-testid="treadmill-text-svg" className="Treadmill-text" viewBox="0 0 100 10" preserveAspectRatio="none">
         <text x="29" y="5" textAnchor="middle" fontSize="5" fill="white">Left</text>
         <text x="79" y="5" textAnchor="middle" fontSize="5" fill="white">Right</text>

--- a/frontend/src/StanceTimeTreadmill.css
+++ b/frontend/src/StanceTimeTreadmill.css
@@ -1,60 +1,128 @@
 .Treadmill {
-    width: 70vw;
-    height: 80vh;
-    margin: 1vh 0;
-    border-color: darkgray;
-    border-style: solid;
-    border-width: .25vw;
-    background-color: white;
+  width: 70vw;
+  height: 80vh;
+  margin: 1vh 0;
+  border-color: darkgray;
+  border-style: solid;
+  border-width: 0.25vw;
+  background-color: white;
 }
 
 .Treadmill-text {
-    background-color: #292c33;
+  background-color: #292c33;
 }
 
 .Treadmill line {
-    stroke-width: .02vw;
+  stroke-width: 0.02vw;
 }
 
 .TargetZones .max-zone {
-    border: 0;
-    fill:  #A3BED4;
+  border: 0;
+  fill: #a3bed4;
 }
 
 .TargetZones .min-zone {
-    stroke: orange;
+  stroke: orange;
 }
 
 .StanceTimeValues line {
-    stroke: black;
+  stroke: black;
 }
 
 .Baseline {
-    stroke: black;
-    stroke-dasharray: .005cm;
+  stroke: black;
+  stroke-dasharray: 0.005cm;
 }
 
 .YAxis {
-    stroke: black;
+  stroke: black;
 }
 
 .visual-key {
-    margin-top: 1vh;
-    padding: 0 0;
-    border-radius: 1vh;
-    border-color: white;
+  margin-top: 1vh;
+  padding: 0 0;
+  border-radius: 1vh;
+  border-color: white;
 }
-  
+
 .visual-key ul {
-    margin-top: .5vh;
-    list-style-type: none;  
-    padding: .25vh .25vw;     
-    margin: 0;   
+  margin-top: 0.5vh;
+  list-style-type: none;
+  padding: 0.25vh 0.25vw;
+  margin: 0;
 }
-  
+
 .visual-key ul li {
-    font-size: 1vw; 
-    padding: .25vh 0;
-    text-align:left;
+  font-size: 1vw;
+  padding: 0.25vh 0;
+  text-align: left;
 }
-  
+
+.stance-time-treadmill-container {
+  position: relative;
+  display: inline-block;
+  width: 100%;
+}
+
+.help-button {
+  position: absolute;
+  top: -25px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 10;
+  padding: 10px 20px;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}
+
+.popup-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 20;
+}
+
+.popup-content {
+  background: #fff;
+  padding: 20px;
+  border-radius: 10px;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  max-width: 500px;
+  text-align: center;
+}
+
+.popup-content h2 {
+  margin-top: 0;
+  color: black;
+}
+
+.popup-content ul {
+  list-style: none;
+  padding: 0;
+  color: black;
+}
+
+.popup-content ul li {
+  margin: 10px 0;
+  text-align: left;
+  color: black;
+}
+
+.close-button {
+  margin-top: 20px;
+  padding: 10px 20px;
+  background-color: #dc3545;
+  color: #fff;
+  border: none;
+  border-radius: 5px;
+  cursor: pointer;
+}


### PR DESCRIPTION
Fixes #78 

What was changed:
The keys and help text was moved to a help button popup.

Why was it changed:
The text at the top was too much and took away from the treamill zone view. The researchers wanted the text only to be seen when necessary.

How was it changed:
A help button was added so that when it was clicked a popup would appear with the help text on it. To exit the popup the close button could be clicked or anywhere outside of the popup div could be clicked
