### PR TITLE
Default View

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,7 +9,7 @@ import ResearcherToolbar from './components/ResearcherToolbar';
 import PatientView from './PatientView';
 
 function App() {
-  const [currentView, setCurrentView] = useState('StanceTimeDigits');
+  const [currentView, setCurrentView] = useState('StanceTimeTredmill');
 
   const [stanceTime, setStanceTime] = useState({
     left: 0, 

--- a/frontend/src/Navigation.js
+++ b/frontend/src/Navigation.js
@@ -4,10 +4,10 @@ function Naviation({ setCurrentView }) {
     return (
         <nav role="navigation" className="Navigation">
             <ul>
-                <li data-testid='stance-time-digits-nav' onClick={() => setCurrentView('StanceTimeDigits')}>Stance Time Digits</li>
-                <li data-testid='stance-time-chart-nav' onClick={() => setCurrentView('StanceTimeChart')}>Stance Time Chart</li>
-                <li data-testid='stance-time-graph-nav' onClick={() => setCurrentView('StanceTimeGraph')}>Stance Time Graph</li>
-                <li data-testid='stance-time-treadmill-nav' onClick={() => setCurrentView('StanceTimeTredmill')}>Stance Time Treadmill</li>
+            <li data-testid='stance-time-treadmill-nav' onClick={() => setCurrentView('StanceTimeTredmill')}>Stance Time Treadmill</li>
+            <li data-testid='stance-time-digits-nav' onClick={() => setCurrentView('StanceTimeDigits')}>Stance Time Digits</li>
+            <li data-testid='stance-time-chart-nav' onClick={() => setCurrentView('StanceTimeChart')}>Stance Time Chart</li>
+            <li data-testid='stance-time-graph-nav' onClick={() => setCurrentView('StanceTimeGraph')}>Stance Time Graph</li>
             </ul>
         </nav>
     );


### PR DESCRIPTION
Fixes #81 

#What was changed:
- The default view rendered on app load has been updated to the treadmill view.
- The navigation panel has been reordered so that the treadmill view button appears first.

#Why was it changed:
- To ensure that when the app opens, users immediately see the treadmill view with all researcher tools.
- To provide an intuitive way for users to switch back to the treadmill view, improving the overall user experience.

#How was it changed:
- Updated the initial state in App.js to set the default view to "StanceTimeTredmill" instead of "StanceTimeDigits".
- Reordered the list items in Naviation.js to place the treadmill view button at the top.

![Screenshot 2025-02-28 093450](https://github.com/user-attachments/assets/dd39de08-c4ed-47c4-b1c7-0f34093a6c7a)

