### PR TITLE
Feature/zone_colors

### DIFF
--- a/frontend/src/StanceTimeTreadmill.js
+++ b/frontend/src/StanceTimeTreadmill.js
@@ -5,6 +5,11 @@ import { HelpCircle } from "lucide-react";
 function StanceTimeTreadmill({ stanceTime }) {
   const [showHelpText, setShowHelpText] = useState(false);
 
+  const xColor = {
+    left:'black',
+    right:'black'
+  }
+
   const scaleFactor = 50;
   const leftScaleFactor = scaleFactor / stanceTime.left;
   const rightScaleFactor = scaleFactor / stanceTime.right;
@@ -28,6 +33,26 @@ function StanceTimeTreadmill({ stanceTime }) {
       setShowHelpText(false);
     }
   }
+
+  // bounds check
+  let isInsideZone = {
+    left: false,
+    right: false
+  }
+
+  if (rightCurrent <= rightMaxPosition && rightCurrent >= rightMinPosition) {
+    isInsideZone.right = true;
+  } else {
+    xColor.right = "red";
+  }
+
+  if (leftCurrent <= leftMaxPosition && leftCurrent >= leftMinPosition) {
+    isInsideZone.left = true;
+  } else {
+    xColor.left = "red";
+  }
+
+  // checks if data is started
 
   return (
     <div data-testid="stance-time-treadmill-view" className="StanceTimeTreadmill" onClick={hideHelp}>
@@ -96,10 +121,10 @@ function StanceTimeTreadmill({ stanceTime }) {
               transition: 'transform 0.25s ease-in-out',
             }}
           >
-            {leftCurrent <= leftMaxPosition && leftCurrent >= leftMinPosition ? (
+            {isInsideZone.left ? (
               <circle cx="29" cy="0" r="2" fill="green" />
             ) : (
-              <text x="29" y="0" fontSize="6" textAnchor="middle" fill="black">x</text>
+              <text x="29" y="0" fontSize="6" textAnchor="middle" fill={xColor.left}>x</text>
             )}
 
           </g>
@@ -110,10 +135,10 @@ function StanceTimeTreadmill({ stanceTime }) {
               transition: 'transform 0.25s ease-in-out',
             }}
           >
-            {rightCurrent <= rightMaxPosition && rightCurrent >= rightMinPosition ? (
+            {isInsideZone.right ? (
               <circle cx="79" cy="0" r="2" fill="green" />
             ) : (
-              <text x="79" y="0" fontSize="6" textAnchor="middle" fill="black">x</text>
+              <text x="79" y="0" fontSize="6" textAnchor="middle" fill={xColor.right}>x</text>
             )}
 
           </g>

--- a/frontend/src/StanceTimeTreadmill.js
+++ b/frontend/src/StanceTimeTreadmill.js
@@ -5,6 +5,7 @@ import { HelpCircle } from "lucide-react";
 function StanceTimeTreadmill({ stanceTime }) {
   const [showHelpText, setShowHelpText] = useState(false);
 
+  const XFontSize = 8;
   const xColor = {
     left:'black',
     right:'black'
@@ -25,8 +26,12 @@ function StanceTimeTreadmill({ stanceTime }) {
   let rightMinPosition = Math.min(scaleFactor + rightOffsetMax, 10);
   // let leftCurrent = stanceTime.left * leftScaleFactor;
   // let rightCurrent = stanceTime.right * rightScaleFactor;
+
+  // TBD
   let leftCurrent = Math.floor(Math.random() * 80);
   let rightCurrent = Math.floor(Math.random() * 80);
+  if (!stanceTime.left) leftCurrent = scaleFactor;
+  if (!stanceTime.right) rightCurrent = scaleFactor;
 
   function hideHelp() {
     if (showHelpText) {
@@ -126,7 +131,7 @@ function StanceTimeTreadmill({ stanceTime }) {
             {isInsideZone.left ? (
               <circle cx="29" cy="0" r="2" fill="green" />
             ) : (
-              <text x="29" y="0" fontSize="6" textAnchor="middle" fill={xColor.left}>x</text>
+              <text x="29" y={XFontSize/4} fontSize={XFontSize} textAnchor="middle" fill={xColor.left}>x</text>
             )}
 
           </g>
@@ -140,7 +145,7 @@ function StanceTimeTreadmill({ stanceTime }) {
             {isInsideZone.right ? (
               <circle cx="79" cy="0" r="2" fill="green" />
             ) : (
-              <text x="79" y="0" fontSize="6" textAnchor="middle" fill={xColor.right}>x</text>
+              <text x="79" y={XFontSize/4} fontSize={XFontSize} textAnchor="middle" fill={xColor.right}>x</text>
             )}
 
           </g>

--- a/frontend/src/StanceTimeTreadmill.js
+++ b/frontend/src/StanceTimeTreadmill.js
@@ -40,19 +40,21 @@ function StanceTimeTreadmill({ stanceTime }) {
     right: false
   }
 
-  if (rightCurrent <= rightMaxPosition && rightCurrent >= rightMinPosition) {
-    isInsideZone.right = true;
-  } else {
-    xColor.right = "red";
+  if (stanceTime.right){
+    if (rightCurrent <= rightMaxPosition && rightCurrent >= rightMinPosition) {
+      isInsideZone.right = true;
+    } else {
+      xColor.right = "red";
+    }
   }
 
-  if (leftCurrent <= leftMaxPosition && leftCurrent >= leftMinPosition) {
-    isInsideZone.left = true;
-  } else {
-    xColor.left = "red";
+  if (stanceTime.left) {
+    if (leftCurrent <= leftMaxPosition && leftCurrent >= leftMinPosition) {
+      isInsideZone.left = true;
+    } else {
+      xColor.left = "red";
+    }
   }
-
-  // checks if data is started
 
   return (
     <div data-testid="stance-time-treadmill-view" className="StanceTimeTreadmill" onClick={hideHelp}>
@@ -78,7 +80,7 @@ function StanceTimeTreadmill({ stanceTime }) {
                 <li>
                   <strong>X's and O's: </strong>
                   A <span style={{ color: "green", fontSize: "2rem" }}>●</span> appears if the step is within range; otherwise, a
-                  <span style={{ color: "black", fontSize: "1rem" }}> X</span> shows the step was out of range.
+                  <span style={{ color: "red", fontSize: "1.1rem" }}> X</span> shows the step was out of range. A black <span style={{ color: "black", fontSize: "1.1rem" }}> X</span> appears if no stance time is found.
                 </li>
 
                 <li>


### PR DESCRIPTION
Adresses issue #98

**What was changed**
The X representing out of bounds stance time is now red normally and black when there's no stance time at all.  A few CSS changes were added to center the X as well.

**Why was it changed**
To clarify and show more information about the stance time to the researcher and the patient.

**How was it changed**
A few conditional statements were added to the StanceTimeTreadmill.js file, to differentiate if stance time data exists from if it exists in a range. The font size was made into a constant and the Y position was made relative to this constant, to align it in the center vertically. 
