### PR TITLE
Replace full-width WebSocket banner with toggle switch

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -7,6 +7,7 @@ import StanceTimeChart from './StanceTimeChart';
 import StanceTimeGraph from './StanceTimeGraph';
 import ResearcherToolbar from './components/ResearcherToolbar';
 import PatientView from './PatientView';
+import WebSocketSwitch from './components/WebSocketSwitch';
 
 function App() {
   const [currentView, setCurrentView] = useState('StanceTimeTreadmill');
@@ -20,8 +21,8 @@ function App() {
     } 
   });
 
-  const [isWebSocketConnected, setIsWebSocketConnected] = useState(false);
-  const [webSocketError, setWebSocketError] = useState(null);
+ const [isWebSocketConnected, setIsWebSocketConnected] = useState(false);
+ const [webSocketError, setWebSocketError] = useState(null);
 
   const [movingAverageFactor, setMovingAverageFactor] = useState(0);
   const [threshold, setThreshold] = useState(0);
@@ -143,12 +144,7 @@ function App() {
 
   return (
     <div className="App">
-      <div className={`WebSocketBanner ${isWebSocketConnected ? 'connected' : 'disconnected'}`}>
-        {isWebSocketConnected
-          ? "Connection established"
-          : webSocketError || "Waiting for WebSocket connection..."}
-        {!isWebSocketConnected && <button onClick={reconnectWebsocket}>Reconnect</button>}
-      </div>
+      <WebSocketSwitch isConnected={isWebSocketConnected} reconnect={reconnectWebsocket} />
       <Navigation setCurrentView={setCurrentView}/>
       {patientWindow && <PatientView borderColor={borderColor} patientWindow={patientWindow} view={views[currentPatientView]}/>}
       <div className="main-layout">

--- a/frontend/src/components/WebSocketSwitch.css
+++ b/frontend/src/components/WebSocketSwitch.css
@@ -1,0 +1,42 @@
+.websocket-toggle {
+    position: fixed;
+    top: 16px;
+    right: 16px;
+    z-index: 1000;
+  }
+  
+  .websocket-toggle input[type="checkbox"] {
+    display: none;
+  }
+  
+  .switch-track {
+    width: 44px;
+    height: 24px;
+    border-radius: 9999px;
+    position: relative;
+    transition: background-color 0.3s;
+  }
+  
+  .switch-track.connected {
+    background-color: #22c55e; /* green */
+  }
+  
+  .switch-track.disconnected {
+    background-color: #ef4444; /* red */
+  }
+  
+  .switch-thumb {
+    width: 16px;
+    height: 16px;
+    background: white;
+    border-radius: 50%;
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    transition: transform 0.3s;
+  }
+  
+  input[type="checkbox"]:checked + .switch-track .switch-thumb {
+    transform: translateX(20px);
+  }
+  

--- a/frontend/src/components/WebSocketSwitch.js
+++ b/frontend/src/components/WebSocketSwitch.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import './WebSocketSwitch.css';
+
+const WebSocketSwitch = ({ isConnected, reconnect }) => {
+  const handleToggle = () => {
+    if (!isConnected) {
+      reconnect();
+    }
+  };
+
+  return (
+    <div className="websocket-toggle" title={isConnected ? 'Connected' : 'Disconnected'}>
+      <label>
+        <input type="checkbox" checked={isConnected} onChange={handleToggle} />
+        <div className={`switch-track ${isConnected ? 'connected' : 'disconnected'}`}>
+          <div className="switch-thumb"></div>
+        </div>
+      </label>
+    </div>
+  );
+};
+
+export default WebSocketSwitch;


### PR DESCRIPTION
Fixes #112 

## What was changed
Replaced the full-width WebSocket status banner with a minimalist toggle switch component. The new switch provides a more compact and less distracting way to show real-time WebSocket connection status while preserving essential user feedback.

## Why was it changed
The original banner spanned the entire screen and consumed valuable screen space, making the interface cluttered and less user-friendly. This update improves the user experience by making the connection status indicator more discreet, consistent with the overall UI design, and easier to interact with.

## How was it changed
- Introduced a new  `WebSocketSwitch` component with green (connected) and red (disconnected) states. 
- Updated `App.js`  to track the WebSocket connection state and pass it to the switch as a prop.
- Clicking the switch while disconnected calls the `reconnectWebsocket()` function from the existing logic.
- The switch visually updates based on WebSocket events `(onopen, onclose, onerror)` to reflect the current connection status.
- CSS styles ensure the switch floats unobtrusively in the top-right corner of the interface.