### PR TITLE
Adding Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Ignore Python cache files
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+
+# Ignore pytest cache
+.pytest_cache/
+
+# Ignore virtual environments
+env/
+venv/
+
+# Ignore Git repo
+.git/
+.gitignore
+
+# Ignore Docker-related stuff
+Dockerfile
+docker-compose.yml
+
+# Ignore MacOS system files
+*.DS_Store
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.11-slim
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY ./backend /app/backend
 
-CMD ["uvicorn" , "main:app", "--reload"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,5 +8,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./backend /app/backend
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "main:app", "--reload"]
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:latest
+
+WORKDIR /app
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn" , "main:app", "--reload"]
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,10 +3,11 @@ FROM python:3.11-slim
 WORKDIR /app
 
 COPY requirements.txt .
+COPY backend/ /app/backend
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY ./backend /app/backend
+WORKDIR /app/backend
 
 CMD ["uvicorn", "main:app", "--reload"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: "3.8"
+
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: backend/Dockerfile
+    ports:
+      - "8000:8000"
+
+  frontend:
+    build: ./frontend
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:latest
+
+WORKDIR /root
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+CMD ["npm", "start"]


### PR DESCRIPTION
Fixes #111 

To run this, you must have Docker installed Docker on your device and have it started. Run `docker-compose up --build
` to start the container. It does take a while at first for it to load. 

What was fixed:
Dockerfiles were added to the frontend and backend folders, and a Docker-compose file was added to the root directory. 

Why was it fixed:
Previously, our project did not have Docker.  We needed to add it to employ a fast containerization process for our system as part of the continuous deployment pipeline.

How it was fixed:
A Dockerfile was created, and runs all of the commands and installs all of the dependencies it needed. From there the Docker-compose starts the backend and then the frontend.